### PR TITLE
Don't validate message type

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,4 @@
+machine:
+  python:
+    version: 3.4.4
+

--- a/stitchclient/client.py
+++ b/stitchclient/client.py
@@ -40,17 +40,13 @@ class Client(object):
         self.callback_function = callback_function
 
     def push(self, message, callback_arg=None):
-        """
-        message must be a dict with at least these keys:
-            action, table_name, key_names, sequence, data
-        and optionally these keys:
-            table_version
+        """message should be a dict recognized by the Stitch Import API.
+
+        See https://www.stitchdata.com/docs/integrations/import-api.
         """
 
         if message['action'] == 'upsert':
             message.setdefault('key_names', self.key_names)
-        else:
-            raise ValueError('Message action property must be "upsert"')
 
         message['client_id'] = self.client_id
         message.setdefault('table_name', self.table_name)


### PR DESCRIPTION
We want to extend python-stitch-client to support other actions, such as "switch_view". This client library isn't currently doing any validation other than asserting that the action is "upsert". If we just remove that assertion we'll get support for "switch_view". I think this is reasonable to do, since we rely on the Stitch Import API to reject messages that are invalid anyway.